### PR TITLE
Get percona signing key from ubuntu keyserver

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,9 @@
 ---
-
+# (do not put quotes on key id, for some reason it won't work)
 - name: "Obtaining percona public key"
-  apt_key: "url=http://www.percona.com/downloads/RPM-GPG-KEY-percona state=present"
+  apt_key: 
+    keyserver: "keyserver.ubuntu.com"
+    id: 8507EFA5
   become: yes
 
 - name: "Adding percona repository"


### PR DESCRIPTION
Percona signing key has changed
( https://www.percona.com/blog/2016/10/13/new-signing-key-for-percona-debian-and-ubuntu-packages/ )
Getting updated keys from keyserver