### PR TITLE
Enclose MySQL root password in quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,12 @@ script:
   #   | grep -q 'changed=0.*failed=0'
   #   && (echo 'Idempotence test: pass' && exit 0)
   #   || (echo 'Idempotence test: fail' && exit 1)
+
+  # Check to make sure we can connect to MySQL as root via Unix socket.
+  - >
+    sudo docker exec "$(cat ${container_id})" mysql -u root -e 'show databases;'
+    | grep -q 'information_schema'
+    && (echo 'OK: Able to login to MySQL server as root' && exit 0)
+    || (echo 'Error: Unable to login to MySQL server as root' && exit 1)
+
   - 'sudo docker rm -f "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+---
+# Based on: 
+#   https://blog.travis-ci.com/2017-11-30-testing-ansible-roles-using-docker-on-travis
+#   https://github.com/drhelius/travis-ansible-demo
+#   https://www.jeffgeerling.com/blog/2018/how-i-test-ansible-configuration-on-7-different-oses-docker 
+
+sudo: required
+
+env:
+  - distribution: ubuntu
+    version: xenial
+  - distribution: ubuntu
+    version: trusty
+
+services:
+  - docker
+
+before_install:
+  - 'sudo docker pull ${distribution}:${version}'
+  - 'sudo docker build --no-cache --rm --file=travis/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible travis'
+
+script:
+  - container_id=$(mktemp)
+  - 'sudo docker run --detach --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${distribution}-${version}:ansible > "${container_id}"'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/role_under_test/travis/test.yml --syntax-check'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/role_under_test/travis/test.yml'
+  ## skipping idempotence tests for now
+  # - >
+  #   sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/clamav_role/travis/test.yml
+  #   | grep -q 'changed=0.*failed=0'
+  #   && (echo 'Idempotence test: pass' && exit 0)
+  #   || (echo 'Idempotence test: fail' && exit 1)
+  - 'sudo docker rm -f "$(cat ${container_id})"'

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Set the root password"
-  mysql_user: "name=root host={{ item }} password={{ mysql_root_password }} check_implicit_admin=yes"
+  mysql_user: "name=root host={{ item }} password=\"{{ mysql_root_password }}\" check_implicit_admin=yes"
   with_items:
     - "{{ ansible_hostname }}"
     - "127.0.0.1"
@@ -11,7 +11,7 @@
   become: yes
 
 - name: "Set the root password"
-  mysql_user: "name=root host={{ item }} password={{ mysql_root_password }} check_implicit_admin=yes"
+  mysql_user: "name=root host={{ item }} password=\"{{ mysql_root_password }}\" check_implicit_admin=yes"
   with_items:
     - "127.0.0.1"
     - "::1"

--- a/templates/root-my-cnf.j2
+++ b/templates/root-my-cnf.j2
@@ -1,3 +1,3 @@
 [client]
 user=root
-password={{ mysql_root_password }}
+password="{{ mysql_root_password }}"

--- a/travis/Dockerfile.ubuntu-trusty
+++ b/travis/Dockerfile.ubuntu-trusty
@@ -1,0 +1,12 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository -y ppa:ansible/ansible && apt-get update && apt-get install -y \
+    git \
+    ansible \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]

--- a/travis/Dockerfile.ubuntu-xenial
+++ b/travis/Dockerfile.ubuntu-xenial
@@ -1,0 +1,12 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository -y ppa:ansible/ansible && apt-get update && apt-get install -y \
+    git \
+    ansible \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]

--- a/travis/test.yml
+++ b/travis/test.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+
+  pre_tasks:
+
+    - name: Ensure build dependencies are installed (Debian)
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - build-essential
+        - unzip
+        - tar
+        - sudo
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - role_under_test

--- a/travis/test.yml
+++ b/travis/test.yml
@@ -2,7 +2,6 @@
 - hosts: all
 
   pre_tasks:
-
     - name: Ensure build dependencies are installed (Debian)
       package:
         name: "{{ item }}"
@@ -13,6 +12,9 @@
         - tar
         - sudo
       when: ansible_os_family == 'Debian'
+
+    - name: Include vars
+      include_vars: "test_role_vars.yml"
 
   roles:
     - role_under_test

--- a/travis/test_role_vars.yml
+++ b/travis/test_role_vars.yml
@@ -1,0 +1,13 @@
+---
+mysql_root_password: "rootpass123"
+
+mysql_databases:
+  - name: "atom"
+    collation: "utf8_general_ci"
+    encoding: "utf8"
+
+mysql_users:
+  - name: "atomuser"
+    pass: "atompass"
+    priv: "atom.*:ALL,GRANT"
+    host: "%"

--- a/travis/test_role_vars.yml
+++ b/travis/test_role_vars.yml
@@ -1,5 +1,5 @@
 ---
-mysql_root_password: "rootpass123"
+mysql_root_password: "rootpass123#!$"
 
 mysql_databases:
   - name: "atom"


### PR DESCRIPTION
The fixes an error I encountered where the root password failed to authenticate because the password included a pound ("#") character. Adding quotes resolved the authentication error.