### PR TITLE
Use default if ansible_python_interpreter is undefined

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,7 +19,7 @@
   become: yes
 
 - name: "Get the major version of python used to run ansible"
-  command: "{{ ansible_python_interpreter }} -c 'import sys; print(sys.version_info.major)'"
+  command: "{{ ansible_python_interpreter | default('/usr/bin/python') }} -c 'import sys; print(sys.version_info.major)'"
   register: ansible_python_major
   changed_when: false
 


### PR DESCRIPTION
When ansible_python_interpreter is undefined, use '/usr/bin/python' to
check the version of the python interpreter used by ansible on the
target host.

Fixes #17