### PR TITLE
Parse temp password in new 5.7 Red Hat installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,13 @@ env:
   - distribution: centos
     version: 7
     ansible_extra_vars: ""
+  - distribution: ubuntu
+    version: xenial
+    ansible_extra_vars: "'mysql_version_major=5 mysql_version_minor=7'"
+  - distribution: centos
+    version: 7
+    ansible_extra_vars: "'mysql_version_major=5 mysql_version_minor=7'"
+
 
 services:
   - docker
@@ -49,5 +56,13 @@ script:
     | grep -q 'information_schema'
     && (echo 'OK: Able to login to MySQL server as root' && exit 0)
     || (echo 'Error: Unable to login to MySQL server as root' && exit 1)
+
+  # Check to make sure we can connect to MySQL as root via TCP.
+  - >
+    sudo docker exec "$(cat ${container_id})" mysql -h 127.0.0.1 -u root -e 'show databases;'
+    | grep -q 'information_schema'
+    && (echo 'OK: Able to login to MySQL server as root' && exit 0)
+    || (echo 'Error: Unable to login to MySQL server as root' && exit 1)
+
 
   - 'sudo docker rm -f "$(cat ${container_id})"'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,3 @@
 
 - name: "Restart percona"
   service: "name=mysql state=restarted"
-  become: yes

--- a/tasks/configure-centos.yml
+++ b/tasks/configure-centos.yml
@@ -5,7 +5,6 @@
     src: "/usr/share/percona-server"
     dest: "/usr/share/mysql"
     state: "link"
-  become: yes
 
 - name: "Update the my.cnf"
   template:
@@ -15,4 +14,3 @@
     mode: 0600
   notify:
     - "Restart percona"
-  become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,4 +4,3 @@
   template: "src=etc_mysql_my.cnf.j2 dest=/etc/mysql/my.cnf owner=root mode=0600"
   notify:
     - "Restart percona"
-  become: yes

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -6,4 +6,3 @@
     encoding: "{{ item.encoding | default('utf8') }}"
     state: "present"
   with_items: "{{ mysql_databases }}"
-  become: "yes"

--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -3,7 +3,6 @@
   yum:
     name: http://www.percona.com/downloads/percona-release/redhat/0.1-4/percona-release-0.1-4.noarch.rpm
     state: present
-  become: yes
 
 - name: "Install percona database server"
   yum:
@@ -15,13 +14,11 @@
     - "Percona-Server-devel-{{mysql_version_major}}{{mysql_version_minor}}"
     - "percona-toolkit"
     - "percona-xtrabackup"
-  become: yes
 
 - name: "Install MySQL-python package"
   yum:
     name: "MySQL-python"
     state: present
-  become: yes
 
 - name: "Adjust permissions of datadir"
   file:
@@ -30,11 +27,9 @@
     group: "mysql"
     mode: 0755
     state: "directory"
-  become: yes
 
 - name: "Ensure that percona is running and enabled"
   service:
     name: "mysql"
     state: "started"
     enabled: "yes"
-  become: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,19 +4,16 @@
   apt_key: 
     keyserver: "keyserver.ubuntu.com"
     id: 8507EFA5
-  become: yes
 
 - name: "Adding percona repository"
   apt_repository:
     repo: "deb http://repo.percona.com/apt {{ ansible_distribution_release }} main"
     state: "present"
-  become: yes
 
 - name: "Update apt cache"
   apt:
     update_cache: yes
     cache_valid_time: 300
-  become: yes
 
 - name: "Get the major version of python used to run ansible"
   command: "{{ ansible_python_interpreter | default('/usr/bin/python') }} -c 'import sys; print(sys.version_info.major)'"
@@ -47,7 +44,6 @@
      - "percona-server-client-{{ mysql_version_major }}.{{ mysql_version_minor }}"
      - "percona-toolkit"
      - "percona-xtrabackup"
-  become: yes
 
 - name: "Adjust permissions of datadir"
   file:
@@ -56,11 +52,9 @@
     group: "mysql"
     mode: 0700
     state: "directory"
-  become: yes
 
 - name: "Ensure that percona is running and enabled"
   service:
     name: "mysql"
     state: "started"
     enabled: "yes"
-  become: yes

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -4,7 +4,6 @@
   stat:
     path: "/root/.my.cnf"
   register: root_my_cnf_stat
-  become: yes
   when:
     - mysql_version_major == "5"
     - mysql_version_minor == "7"
@@ -29,7 +28,6 @@
         owner: root
         group: root
         mode: 0600
-  become: yes
   when:
     - mysql_version_major == "5"
     - mysql_version_minor == "7"
@@ -49,7 +47,6 @@
     - "::1"
     - "localhost"
   when: "ansible_hostname != 'localhost'"
-  become: yes
 
 - name: "Set the root password"
   mysql_user:
@@ -63,7 +60,6 @@
     - "::1"
     - "localhost"
   when: "ansible_hostname == 'localhost'"
-  become: yes
 
 - name: "Copy .my.cnf file into the root home folder"
   template:
@@ -72,7 +68,6 @@
     owner: root
     group: root
     mode: 0600
-  become: yes
 
 - name: "Ensure anonymous users are not in the database"
   mysql_user:
@@ -82,10 +77,8 @@
   with_items:
     - "{{ ansible_hostname }}"
     - "localhost"
-  become: yes
 
 - name: "Remove the test database"
   mysql_db:
     name: test
     state: absent
-  become: yes

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -1,5 +1,41 @@
 ---
 
+- name: "Check if /root/.my.cnf file exists if installing 5.7 on Red Hat (to determine if new install)"
+  stat:
+    path: "/root/.my.cnf"
+  register: root_my_cnf_stat
+  become: yes
+  when:
+    - mysql_version_major == "5"
+    - mysql_version_minor == "7"
+    - ansible_os_family == "RedHat"
+
+- name: "Percona 5.7 new install measures (Red Hat)"
+  block:
+    - name: "Parse temporary password from mysql log"
+      shell: "cat /var/log/mysqld.log | sed -n 's/.*temporary password is generated for root@localhost: //p'"
+      register: temppass
+
+    # Set root password 
+    # (mysql_user module can't be used here, got error 1862 'Your password has expired. To log in you must change it using a client that supports expired passwords.')
+    # escape single quotes in shell with '' not \'
+    - name: "Set root password (using temp password to log in)"
+      shell: 'mysql -e "SET PASSWORD = PASSWORD(''{{ mysql_root_password }}'');" --connect-expired-password -uroot -p"{{ temppass.stdout }}"'
+
+    - name: "add /root/.my.cnf with root password"
+      template:
+        src: root-my-cnf.j2
+        dest: /root/.my.cnf
+        owner: root
+        group: root
+        mode: 0600
+  become: yes
+  when:
+    - mysql_version_major == "5"
+    - mysql_version_minor == "7"
+    - ansible_os_family == "RedHat"
+    - root_my_cnf_stat.stat.exists == False
+
 - name: "Set the root password"
   mysql_user:
     name: root

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,4 +8,3 @@
     state: "present"
     host: "{{ item.host | default('localhost') }}"
   with_items: "{{ mysql_users }}"
-  become: "yes"

--- a/travis/test_role_vars.yml
+++ b/travis/test_role_vars.yml
@@ -1,5 +1,5 @@
 ---
-mysql_root_password: "rootpass123#!$"
+mysql_root_password: "rootPASS123#!$"
 
 mysql_databases:
   - name: "atom"
@@ -8,6 +8,6 @@ mysql_databases:
 
 mysql_users:
   - name: "atomuser"
-    pass: "atompass"
+    pass: "atomPASS9876."
     priv: "atom.*:ALL,GRANT"
     host: "%"


### PR DESCRIPTION
Starting from 5.7, Percona/MySQL sets up a random temp password on
CentOS/Red Hat (no root password was set up on 5.6 and earlier)

- Parse temporary root password and use it to log in to the server and
  set up the desired root password.
- Travis: add tests for 5.7, modify password used in test to satisfy
  default 5.7 security requirements, add test to check if possible to
  log in using TCP (in addition to UNIX sockets)

Fixes #19