### PR TITLE
Increase mysql_innodb_log_file_size default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ mysql_innodb_buffer_pool_size: "128M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: "50"
 mysql_innodb_log_buffer_size: "1M"
-mysql_innodb_log_file_size: "5M"
+mysql_innodb_log_file_size: "64M"
 
 mysql_character_set_client_handshake: "FALSE"
 


### PR DESCRIPTION
Increase mysql_innodb_log_file_size default (ref. Percona blog [1])

Related to https://github.com/artefactual/archivematica/issues/789

[1] https://www.percona.com/blog/2011/11/21/should-mysql-update-the-default-innodb_log_file_size/