### PR TITLE
Updates for Percona 5.7

### DIFF
--- a/tasks/configure-centos.yml
+++ b/tasks/configure-centos.yml
@@ -11,6 +11,6 @@
     src: "etc_my.cnf-centos.j2"
     dest: "/etc/my.cnf"
     owner: "root"
-    mode: 0600
+    mode: 0644
   notify:
     - "Restart percona"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: "Update the my.cnf"
-  template: "src=etc_mysql_my.cnf.j2 dest=/etc/mysql/my.cnf owner=root mode=0600"
+  template: "src=etc_mysql_my.cnf.j2 dest=/etc/mysql/my.cnf owner=root mode=0644"
   notify:
     - "Restart percona"

--- a/templates/etc_my.cnf-centos.j2
+++ b/templates/etc_my.cnf-centos.j2
@@ -28,6 +28,9 @@ port        = {{ mysql_port }}
 basedir     = /usr
 datadir     = {{ mysql_datadir }}
 tmpdir      = /tmp
+{% if mysql_sql_mode is defined %}
+sql_mode={{ mysql_sql_mode }}
+{% endif %}
 
 # language is for pre-5.5. In 5.5 it is an alias for lc_messages_dir.
 language = {{ mysql_language }}
@@ -39,10 +42,16 @@ key_buffer_size         = {{ mysql_key_buffer }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
 thread_stack            = {{ mysql_thread_stack }}
 thread_cache_size       = {{ mysql_cache_size }}
+{% if mysql_version_minor < 7 %}
 myisam-recover          = {{ mysql_myisam_recover }}
+{% else %}
+myisam-recover-options  = {{ mysql_myisam_recover }}
+{% endif %}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
+{% if mysql_version_minor < 7 %}
 thread_concurrency      = {{ mysql_thread_concurrency }}
+{% endif %}
 
 # ** Query Cache Configuration
 query_cache_limit       = {{ mysql_query_cache_limit }}

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -22,8 +22,12 @@ port        = {{ mysql_port }}
 basedir     = /usr
 datadir     = {{ mysql_datadir }}
 tmpdir      = /tmp
+{% if mysql_version_minor < 6 %}
 # language is for pre-5.5. In 5.5 it is an alias for lc_messages_dir.
 language = {{ mysql_language }}
+{% else %}
+lc_messages_dir = {{ mysql_language }}
+{% endif %}
 bind-address = {{ mysql_bind_address }}
 skip-external-locking
 
@@ -32,10 +36,16 @@ key_buffer_size         = {{ mysql_key_buffer }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
 thread_stack            = {{ mysql_thread_stack }}
 thread_cache_size       = {{ mysql_cache_size }}
+{% if mysql_version_minor < 7 %}
 myisam-recover          = {{ mysql_myisam_recover }}
+{% else %}
+myisam-recover-options  = {{ mysql_myisam_recover }}
+{% endif %}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
+{% if mysql_version_minor < 7 %}
 thread_concurrency      = {{ mysql_thread_concurrency }}
+{% endif %}
 
 # ** Query Cache Configuration
 query_cache_limit       = {{ mysql_query_cache_limit }}

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -30,6 +30,9 @@ lc_messages_dir = {{ mysql_language }}
 {% endif %}
 bind-address = {{ mysql_bind_address }}
 skip-external-locking
+{% if mysql_sql_mode is defined %}
+sql_mode={{ mysql_sql_mode }}
+{% endif %}
 
 # * Fine Tuning
 key_buffer_size         = {{ mysql_key_buffer }}


### PR DESCRIPTION
 - Permissions for my.cnf were too restrictive, changed to 0644
 - Renamed myisam-recover and language settings for 5.7
 - Removed thread_concurrency for 5.7 (deprecated)
 - Add sql_mode variable (needed for atom 2.5 deployments)
