### PR TITLE
python3: cast vars to int in my.cnf template

### DIFF
--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -22,7 +22,7 @@ port        = {{ mysql_port }}
 basedir     = /usr
 datadir     = {{ mysql_datadir }}
 tmpdir      = /tmp
-{% if mysql_version_minor < 6 %}
+{% if mysql_version_minor|int < 6 %}
 # language is for pre-5.5. In 5.5 it is an alias for lc_messages_dir.
 language = {{ mysql_language }}
 {% else %}
@@ -39,14 +39,14 @@ key_buffer_size         = {{ mysql_key_buffer }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
 thread_stack            = {{ mysql_thread_stack }}
 thread_cache_size       = {{ mysql_cache_size }}
-{% if mysql_version_minor < 7 %}
+{% if mysql_version_minor|int < 7 %}
 myisam-recover          = {{ mysql_myisam_recover }}
 {% else %}
 myisam-recover-options  = {{ mysql_myisam_recover }}
 {% endif %}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
-{% if mysql_version_minor < 7 %}
+{% if mysql_version_minor|int < 7 %}
 thread_concurrency      = {{ mysql_thread_concurrency }}
 {% endif %}
 


### PR DESCRIPTION
Cast ansible vars before comparing to int, to avoid errors with
ansible running on python 3