### PR TITLE
Add Percona 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,28 +10,50 @@ notifications:
 sudo: required
 
 env:
-  - distribution: ubuntu
-    version: bionic
-    ansible_extra_vars: "'mysql_version_major=5 mysql_version_minor=7'"
-  - distribution: ubuntu
-    version: xenial
-    ansible_extra_vars: "ansible_python_interpreter=/usr/bin/python3"
-  - distribution: ubuntu
-    version: xenial
-    ansible_extra_vars: ""
+  # Trusty + Percona Server 5.6
   - distribution: ubuntu
     version: trusty
     ansible_extra_vars: ""
-  - distribution: centos
-    version: 7
+  # Bionic + Percona Server 5.6
+  - distribution: ubuntu
+    version: bionic
     ansible_extra_vars: ""
+  # Bionic + Percona Server 5.7
+  - distribution: ubuntu
+    version: bionic
+    ansible_extra_vars: "'mysql_version_major=5 mysql_version_minor=7'"
+  # Bionic + Percona Server 8.0
+  - distribution: ubuntu
+    version: bionic
+    ansible_extra_vars: "'mysql_version_major=8 mysql_version_minor=0 mysql_default_authentication_plugin=mysql_native_password'"
+  # Xenial + Percona Server 5.6 with python3
+  - distribution: ubuntu
+    version: xenial
+    ansible_extra_vars: "ansible_python_interpreter=/usr/bin/python3"
+  # Xenial + Percona Server 5.6
+  - distribution: ubuntu
+    version: xenial
+    ansible_extra_vars: ""
+  # Xenial + Percona Server 5.7
   - distribution: ubuntu
     version: xenial
     ansible_extra_vars: "'mysql_version_major=5 mysql_version_minor=7'"
+  # Xenial + Percona Server 8.0
+  - distribution: ubuntu
+    version: xenial
+    ansible_extra_vars: "'mysql_version_major=8 mysql_version_minor=0 mysql_default_authentication_plugin=mysql_native_password'"
+  # CentOS + Percona Server 5.6
+  - distribution: centos
+    version: 7
+    ansible_extra_vars: ""
+  # CentOS + Percona Server 5.7
   - distribution: centos
     version: 7
     ansible_extra_vars: "'mysql_version_major=5 mysql_version_minor=7'"
-
+  # CentOS + Percona Server 8.0
+  - distribution: centos
+    version: 7
+    ansible_extra_vars: "'mysql_version_major=8 mysql_version_minor=0 mysql_default_authentication_plugin=mysql_native_password'
 
 services:
   - docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 # Version to install, defaulting to 5.6
 mysql_version_major: "5"
 mysql_version_minor: "6"
+mysql_version: "{{ mysql_version_major|int }}.{{ mysql_version_minor|int }}"
 
 # Basic settings
 mysql_root_password: "pass"
@@ -42,3 +43,7 @@ mysql_databases: []
 mysql_users: []
 
 install_rpm_repositories: "true"
+
+# Default Auth Plugin
+# used in templates when Percona Server >= 5.7
+mysql_default_authentication_plugin: "mysql_native_password"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,8 @@ galaxy_info:
   author: "Artefactual Systems"
   company: "Artefactual Systems"
   license: AGPLv3
-  min_ansible_version: 1.4
+  min_ansible_version: 2.5
+  max_ansible_version: 2.8
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/configure-centos.yml
+++ b/tasks/configure-centos.yml
@@ -12,5 +12,25 @@
     dest: "/etc/my.cnf"
     owner: "root"
     mode: 0644
+  register: "config_file"
   notify:
     - "Restart percona"
+
+- name: "Ensure that percona is running and enabled"
+  service:
+    name: "mysql"
+    state: "started"
+    enabled: "yes"
+  register: mysql_service
+
+# This service restart is needed when changing default mysql_datadir, mysql_native_password
+# and other settings. So better restart when the my.cnf file changes
+# Restart when my.cnf has changed and it has not been restarted by the above task
+- name: "Restart mysql to apply changes done in my.cnf file"
+  service:
+    name: "mysql"
+    state: "restarted"
+  when:
+    - config_file.changed
+    - mysql_service is defined
+    - not mysql_service.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,5 +2,25 @@
 
 - name: "Update the my.cnf"
   template: "src=etc_mysql_my.cnf.j2 dest=/etc/mysql/my.cnf owner=root mode=0644"
+  register: "config_file"
   notify:
     - "Restart percona"
+
+- name: "Ensure that percona is running and enabled"
+  service:
+    name: "mysql"
+    state: "started"
+    enabled: "yes"
+  register: mysql_service
+
+# This service restart is needed when changing default mysql_datadir, mysql_native_password
+# and other settings. So better restart when the my.cnf file changes
+# Restart when my.cnf has changed and it has not been restarted by the above task
+- name: "Restart mysql to apply changes done in my.cnf file"
+  service:
+    name: "mysql"
+    state: "restarted"
+  when:
+    - config_file.changed
+    - mysql_service is defined
+    - not mysql_service.changed

--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -5,14 +5,32 @@
     state: present
   when: install_rpm_repositories|bool
 
-- name: "Install percona database server"
+# https://www.percona.com/doc/percona-server/LATEST/installation/yum_repo.html
+- name: "Enable Percona repository (Percona version >= 8)"
+  command: "percona-release setup ps{{ mysql_version_major }}{{ mysql_version_minor }}"
+  when: mysql_version_major|int >= 8 and install_rpm_repositories|bool
+ 
+- name: "Install percona database server (Percona version < 8)"
   yum:
-    name: [ 'Percona-Server-server-{{mysql_version_major}}{{mysql_version_minor}}',
-            'Percona-Server-client-{{mysql_version_major}}{{mysql_version_minor}}',
-            'Percona-Server-devel-{{mysql_version_major}}{{mysql_version_minor}}',
-            'percona-toolkit',
-            'percona-xtrabackup' ]
+    name: 
+      - "Percona-Server-server-{{mysql_version_major}}{{mysql_version_minor}}"
+      - "Percona-Server-client-{{mysql_version_major}}{{mysql_version_minor}}"
+      - "Percona-Server-devel-{{mysql_version_major}}{{mysql_version_minor}}"
+      - "percona-toolkit"
+      - "percona-xtrabackup"
     state: present
+  when: mysql_version_major|int < 8
+
+- name: "Install percona database server (Percona version >= 8)"
+  yum:
+    name: 
+      - "percona-server-server-{{mysql_version_major}}.{{mysql_version_minor}}*"
+      - "percona-server-client-{{mysql_version_major}}.{{mysql_version_minor}}*"
+      - "percona-server-devel-{{mysql_version_major}}.{{mysql_version_minor}}*"
+      - "percona-toolkit"
+      - "percona-xtrabackup"
+    state: present
+  when: mysql_version_major|int >= 8
 
 - name: "Install MySQL-python package"
   yum:
@@ -26,9 +44,3 @@
     group: "mysql"
     mode: 0755
     state: "directory"
-
-- name: "Ensure that percona is running and enabled"
-  service:
-    name: "mysql"
-    state: "started"
-    enabled: "yes"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,16 @@
     update_cache: yes
     cache_valid_time: 300
 
+- name: "Install percona-release package (Percona version >= 8)"
+  apt:
+    deb: "https://repo.percona.com/apt/percona-release_latest.{{ ansible_distribution_release }}_all.deb"
+  when: mysql_version_major|int >= 8
+
+# https://www.percona.com/doc/percona-server/LATEST/installation/apt_repo.html
+- name: "Enable Percona repository (Percona version >= 8)"
+  command: "percona-release setup ps{{ mysql_version_major }}{{ mysql_version_minor }}"
+  when: mysql_version_major|int >= 8
+
 - name: "Get the major version of python used to run ansible"
   command: "{{ ansible_python_interpreter | default('/usr/bin/python') }} -c 'import sys; print(sys.version_info.major)'"
   register: ansible_python_major
@@ -35,13 +45,37 @@
   when:
     - ansible_python_major.stdout == "3"
 
-- name: "Install percona packages and dependencies on Ubuntu"
+- name: "Install percona packages and dependencies on Ubuntu (Percona version < 8)"
   apt:
-    name: [ 'percona-server-server-{{ mysql_version_major }}.{{ mysql_version_minor }}',
-            'percona-server-client-{{ mysql_version_major }}.{{ mysql_version_minor }}',
-            'percona-toolkit',
-            'percona-xtrabackup' ]
+    name: 
+      - "percona-server-server-{{ mysql_version_major }}.{{ mysql_version_minor }}"
+      - "percona-server-client-{{ mysql_version_major }}.{{ mysql_version_minor }}"
+      - "percona-toolkit"
+      - "percona-xtrabackup"
     state: "present"
+  when: mysql_version_major|int < 8
+
+- name: "Install | configure debconf for version 8.0 (Use Legacy Authentication Method)"
+  debconf:
+    name: 'percona-server-server'
+    question: 'percona-server-server/default-auth-override'
+    value: 'Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)'
+    vtype: select
+  changed_when: false
+  when:
+    - mysql_version_major|int >= 8
+    - mysql_default_authentication_plugin is defined
+    - mysql_default_authentication_plugin == "mysql_native_password"
+
+- name: "Install percona packages and dependencies on Ubuntu (Percona version >= 8)"
+  apt:
+    name:
+      - "percona-server-server={{ mysql_version_major }}.{{ mysql_version_minor }}*"
+      - "percona-server-client={{ mysql_version_major }}.{{ mysql_version_minor }}*"
+      - "percona-toolkit"
+      - "percona-xtrabackup"
+    state: "present"
+  when: mysql_version_major|int >= 8
  
 - name: "Adjust permissions of datadir"
   file:
@@ -50,9 +84,3 @@
     group: "mysql"
     mode: 0700
     state: "directory"
-
-- name: "Ensure that percona is running and enabled"
-  service:
-    name: "mysql"
-    state: "started"
-    enabled: "yes"

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -1,38 +1,37 @@
 ---
 
-- name: "Check if /root/.my.cnf file exists if installing 5.7 on Red Hat (to determine if new install)"
+- name: "Check if /root/.my.cnf file exists if installing >= 5.7 on Red Hat (to determine if new install)"
   stat:
     path: "/root/.my.cnf"
   register: root_my_cnf_stat
   when:
-    - mysql_version_major == "5"
-    - mysql_version_minor == "7"
+    - mysql_version is version('5.7', '>=')
     - ansible_os_family == "RedHat"
 
-- name: "Percona 5.7 new install measures (Red Hat)"
+- name: "Percona >= 5.7 new install measures (Red Hat)"
   block:
-    - name: "Parse temporary password from mysql log"
-      shell: "cat /var/log/mysqld.log | sed -n 's/.*temporary password is generated for root@localhost: //p'"
+    - name: "Parse temporary password from mysql log, getting last one"
+      shell: "cat /var/log/mysqld.log | sed -n 's/.*temporary password is generated for root@localhost: //p' | tail -n1"
       register: temppass
 
     # Set root password 
     # (mysql_user module can't be used here, got error 1862 'Your password has expired. To log in you must change it using a client that supports expired passwords.')
     # escape single quotes in shell with '' not \'
     - name: "Set root password (using temp password to log in)"
-      shell: 'mysql -e "SET PASSWORD = PASSWORD(''{{ mysql_root_password }}'');" --connect-expired-password -uroot -p"{{ temppass.stdout }}"'
+      shell: 'mysql -e "SET PASSWORD = ''{{ mysql_root_password }}'';" --connect-expired-password -uroot -p"{{ temppass.stdout }}"'
 
-    - name: "add /root/.my.cnf with root password"
-      template:
-        src: root-my-cnf.j2
-        dest: /root/.my.cnf
-        owner: root
-        group: root
-        mode: 0600
   when:
-    - mysql_version_major == "5"
-    - mysql_version_minor == "7"
+    - mysql_version is version('5.7', '>=')
     - ansible_os_family == "RedHat"
     - root_my_cnf_stat.stat.exists == False
+
+- name: "Copy .my.cnf file into the root home folder"
+  template:
+    src: root-my-cnf.j2
+    dest: /root/.my.cnf
+    owner: root
+    group: root
+    mode: 0600
 
 - name: "Set the root password"
   mysql_user:
@@ -46,28 +45,6 @@
     - "127.0.0.1"
     - "::1"
     - "localhost"
-  when: "ansible_hostname != 'localhost'"
-
-- name: "Set the root password"
-  mysql_user:
-    name: root
-    host: "{{ item }}"
-    password: "{{ mysql_root_password }}"
-    check_implicit_admin: yes
-    state: present
-  with_items:
-    - "127.0.0.1"
-    - "::1"
-    - "localhost"
-  when: "ansible_hostname == 'localhost'"
-
-- name: "Copy .my.cnf file into the root home folder"
-  template:
-    src: root-my-cnf.j2
-    dest: /root/.my.cnf
-    owner: root
-    group: root
-    mode: 0600
 
 - name: "Ensure anonymous users are not in the database"
   mysql_user:

--- a/templates/etc_my.cnf-centos.j2
+++ b/templates/etc_my.cnf-centos.j2
@@ -31,6 +31,9 @@ tmpdir      = /tmp
 {% if mysql_sql_mode is defined %}
 sql_mode={{ mysql_sql_mode }}
 {% endif %}
+{% if mysql_default_authentication_plugin is defined and mysql_version is version('5.7', '>=') %}
+default_authentication_plugin={{ mysql_default_authentication_plugin }}
+{% endif %}
 
 # language is for pre-5.5. In 5.5 it is an alias for lc_messages_dir.
 language = {{ mysql_language }}
@@ -42,23 +45,29 @@ key_buffer_size         = {{ mysql_key_buffer }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
 thread_stack            = {{ mysql_thread_stack }}
 thread_cache_size       = {{ mysql_cache_size }}
-{% if mysql_version_minor < 7 %}
+{% if  mysql_version is version('5.7', '<') %}
 myisam-recover          = {{ mysql_myisam_recover }}
 {% else %}
 myisam-recover-options  = {{ mysql_myisam_recover }}
 {% endif %}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
-{% if mysql_version_minor < 7 %}
+{% if  mysql_version is version('5.7', '<') %}
 thread_concurrency      = {{ mysql_thread_concurrency }}
 {% endif %}
 
-# ** Query Cache Configuration
+# ** Query Cache Configuration, removed in MySQL >= 8.0
+{% if mysql_version_major|int < 8 %}
 query_cache_limit       = {{ mysql_query_cache_limit }}
 query_cache_size        = {{ mysql_query_cache_size }}
+{% endif %}
 # ** Logging and Replication
 log_error = /var/log/mysqld.log
+{% if mysql_version_major|int < 8 %}
 log_warnings = 2
+{% else %}
+log_error_verbosity = 2
+{% endif %}
 #general_log_file        = /var/log/mysql/mysqld.log
 #general_log             = 1
 #

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -22,7 +22,7 @@ port        = {{ mysql_port }}
 basedir     = /usr
 datadir     = {{ mysql_datadir }}
 tmpdir      = /tmp
-{% if mysql_version_minor < 6 %}
+{% if  mysql_version is version('5.7', '<') %}
 # language is for pre-5.5. In 5.5 it is an alias for lc_messages_dir.
 language = {{ mysql_language }}
 {% else %}
@@ -33,30 +33,39 @@ skip-external-locking
 {% if mysql_sql_mode is defined %}
 sql_mode={{ mysql_sql_mode }}
 {% endif %}
+{% if mysql_default_authentication_plugin is defined and mysql_version is version('5.7', '>=') %}
+default_authentication_plugin={{ mysql_default_authentication_plugin }}
+{% endif %}
 
 # * Fine Tuning
 key_buffer_size         = {{ mysql_key_buffer }}
 max_allowed_packet      = {{ mysql_max_allowed_packet }}
 thread_stack            = {{ mysql_thread_stack }}
 thread_cache_size       = {{ mysql_cache_size }}
-{% if mysql_version_minor < 7 %}
+{% if  mysql_version is version('5.7', '<') %}
 myisam-recover          = {{ mysql_myisam_recover }}
 {% else %}
 myisam-recover-options  = {{ mysql_myisam_recover }}
 {% endif %}
 max_connections         = {{ mysql_max_connections }}
 table_open_cache        = {{ mysql_table_cache }}
-{% if mysql_version_minor < 7 %}
+{% if  mysql_version is version('5.7', '<') %}
 thread_concurrency      = {{ mysql_thread_concurrency }}
 {% endif %}
 
-# ** Query Cache Configuration
+# ** Query Cache Configuration, removed in MySQL >= 8.0
+{% if mysql_version_major|int < 8 %}
 query_cache_limit       = {{ mysql_query_cache_limit }}
 query_cache_size        = {{ mysql_query_cache_size }}
+{% endif %}
 
 # ** Logging and Replication
 log_error = /var/log/mysql/error.log
+{% if mysql_version_major|int < 8 %}
 log_warnings = 2
+{% else %}
+log_error_verbosity = 2
+{% endif %}
 #general_log_file        = /var/log/mysql/mysql.log
 #general_log             = 1
 #


### PR DESCRIPTION
This PR adds:

- MySQL 8 support
- Move "Ensure mysql service is up" task to configure files.
- Restart mysql when changing config file before adding users/databases.
- Remove `query_cache` variables for MySQL >= 8.0.
- Use `log_error_verbosity` instead of `log_warnings` when MySQL >= 8.0.
- Modify/Reorder secure.yml to make it clearer.
- Cast vars to int in my.cnf templates.
- Change the packages list format in yum annd apt tasks.
- Increase mininum ansible version to 2.5.

Connects to https://github.com/artefactual-labs/ansible-percona/issues/38