### PR TITLE
Tests: Remove pin ansible version to 2.8 on CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Adapted from https://github.com/hpcloud-mon/ansible-percona
 
 ## Requirements
 
-Ansible >= 2.5 and <= 2.8. 
-See https://github.com/artefactual-labs/ansible-percona/issues/41
+Ansible >= 2.5
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,6 @@ galaxy_info:
   company: "Artefactual Systems"
   license: AGPLv3
   min_ansible_version: 2.5
-  max_ansible_version: 2.8
   platforms:
     - name: Ubuntu
       versions:

--- a/travis/Dockerfile.centos-7
+++ b/travis/Dockerfile.centos-7
@@ -13,10 +13,7 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN yum -y install epel-release
-RUN yum -y install git python2-pip sudo ansible
-
-RUN pip install -U pip
-RUN pip install ansible==2.8
+RUN yum -y install git ansible sudo
 
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 


### PR DESCRIPTION
CentOS is using ansible 2.9.2, so the issue #41 is fixed. See:

The `max_ansible_version: 2.8` setting was removed.

Connects to #41.