### PR TITLE
Increase value for some default variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ mysql_datadir: "/var/lib/mysql"
 
 # Fine tuning
 mysql_key_buffer: "16M"
-mysql_max_allowed_packet: "128M"
+mysql_max_allowed_packet: "256M"
 mysql_thread_stack: "192K"
 mysql_cache_size: "8"
 mysql_myisam_recover: "BACKUP"
@@ -31,11 +31,11 @@ mysql_isamchk_key_buffer: "16M"
 # InnoDB tuning
 mysql_innodb_file_per_table: "1"
 mysql_innodb_flush_method: "fdatasync"
-mysql_innodb_buffer_pool_size: "128M"
+mysql_innodb_buffer_pool_size: "256M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: "50"
 mysql_innodb_log_buffer_size: "1M"
-mysql_innodb_log_file_size: "5M"
+mysql_innodb_log_file_size: "64M"
 
 mysql_character_set_client_handshake: "FALSE"
 

--- a/tasks/check-settings-centos.yml
+++ b/tasks/check-settings-centos.yml
@@ -1,0 +1,20 @@
+---
+
+- name: "Check if percona-server is installed"
+  shell: rpm -qa | grep -i percona-server-server
+  ignore_errors: yes
+  register: percona_server_is_installed
+
+- name: "Check for innodb_log_file_size setting (RedHat/CentOS)"
+  shell:
+    cmd: grep -E ^innodb_log_file_size /etc/my.cnf | awk -F= '{ print $2}' | sed 's/\s//g'
+    removes: "/etc/my.cnf"
+  register: configured_innodb_log_file_size
+
+- name: "Abort when innodb_log_file_size changes"
+  fail:
+    msg: "The existing MySQL server has innodb_log_file_size={{ configured_innodb_log_file_size.stdout }}, but your are trying to set it to {{ mysql_innodb_log_file_size }}. Please, change this value for the variable in either ansible or the server itself. See: https://dev.mysql.com/doc/refman/5.6/en/innodb-redo-log.html"
+  when:
+    - percona_server_is_installed.stdout|trim != ""
+    - not configured_innodb_log_file_size.stdout | regex_search('^skipped')
+    - configured_innodb_log_file_size.stdout != mysql_innodb_log_file_size

--- a/tasks/check-settings.yml
+++ b/tasks/check-settings.yml
@@ -1,0 +1,20 @@
+---
+
+- name: "Check if percona-server is installed"
+  shell: dpkg -l | grep -i percona-server-server
+  ignore_errors: yes
+  register: percona_server_is_installed
+
+- name: "Check for innodb_log_file_size setting (Ubuntu)"
+  shell: 
+    cmd: grep -E ^innodb_log_file_size /etc/mysql/my.cnf | awk -F= '{ print $2}' | sed 's/\s//g'
+    removes: "/etc/mysql/my.cnf"
+  register: configured_innodb_log_file_size
+
+- name: "Abort when innodb_log_file_size changes"
+  fail:
+    msg: "The existing MySQL server has innodb_log_file_size={{ configured_innodb_log_file_size.stdout }}, but your are trying to set it to {{ mysql_innodb_log_file_size }}. Please, change this value for the variable in either ansible or the server itself. See: https://dev.mysql.com/doc/refman/5.6/en/innodb-redo-log.html"
+  when:
+    - percona_server_is_installed.stdout|trim != ""
+    - not configured_innodb_log_file_size.stdout | regex_search('^skipped')
+    - configured_innodb_log_file_size.stdout != mysql_innodb_log_file_size

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- include: check-settings.yml
+  tags: check
+  when: ansible_os_family != "RedHat"
+
+- include: check-settings-centos.yml
+  tags: check
+  when: ansible_os_family == "RedHat"
+
 - include: install.yml
   tags: install
   when: ansible_os_family != "RedHat"


### PR DESCRIPTION
There are some variables that have a low default value.

The variable `mysql_innodb_log_file_size` needs a special treatment when
MySQL version is < 5.7. This is why the check tasks were added.

Connects to https://github.com/archivematica/Issues/issues/956