### PR TITLE
Change the way passwords are updated

### DIFF
--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -33,13 +33,16 @@
     group: root
     mode: 0600
 
-- name: "Set the root password"
-  mysql_user:
-    name: root
-    host: "{{ item }}"
-    password: "{{ mysql_root_password }}"
-    check_implicit_admin: yes
-    state: present
+# See: 
+# https://github.com/ansible/ansible/issues/41116 
+# https://github.com/ansible/ansible/pull/45355
+# https://stackoverflow.com/questions/40050219/rootlocalhost-password-set-with-ansible-mysql-user-module-doesnt-work
+# mysql_user ansible module and check_implicit_admin fails with ansible =< 2.9.1: 
+- name: "Set the root password pluging (>=8.0)"
+  shell: |
+    mysql -e "FLUSH PRIVILEGES;"
+    mysql -e "CREATE USER IF NOT EXISTS 'root'@'{{ item }}' IDENTIFIED WITH mysql_native_password BY '{{ mysql_root_password }}';"
+    mysql -e "ALTER USER IF EXISTS 'root'@'{{ item }}' IDENTIFIED WITH mysql_native_password BY '{{ mysql_root_password }}';"
   with_items:
     - "{{ ansible_hostname }}"
     - "127.0.0.1"


### PR DESCRIPTION
Avoids using mysql_db and run mysql queries

 https://github.com/ansible/ansible/issues/41116
 https://github.com/ansible/ansible/pull/45355
 https://stackoverflow.com/questions/40050219/rootlocalhost-password-set-with-ansible-mysql-user-module-doesnt-work