### PR TITLE
Add sort_buffer_size variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ mysql_character_set_server: "utf8"
 mysql_collation_server: "utf8_general_ci"
 mysql_mysqldump_max_allowed_packet: "128M"
 mysql_isamchk_key_buffer: "16M"
+mysql_sort_buffer_size: "256K"
 
 # InnoDB tuning
 mysql_innodb_file_per_table: "1"

--- a/templates/etc_my.cnf-centos.j2
+++ b/templates/etc_my.cnf-centos.j2
@@ -55,6 +55,7 @@ table_open_cache        = {{ mysql_table_cache }}
 {% if  mysql_version is version('5.7', '<') %}
 thread_concurrency      = {{ mysql_thread_concurrency }}
 {% endif %}
+sort_buffer_size        = {{ mysql_sort_buffer_size }}
 
 # ** Query Cache Configuration, removed in MySQL >= 8.0
 {% if mysql_version_major|int < 8 %}

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -52,6 +52,7 @@ table_open_cache        = {{ mysql_table_cache }}
 {% if  mysql_version is version('5.7', '<') %}
 thread_concurrency      = {{ mysql_thread_concurrency }}
 {% endif %}
+sort_buffer_size        = {{ mysql_sort_buffer_size }}
 
 # ** Query Cache Configuration, removed in MySQL >= 8.0
 {% if mysql_version_major|int < 8 %}


### PR DESCRIPTION
The variable has been added to templates. The default value (256K) is the same
that MySQL uses when the variable is not defined in my.cnf file.

Connects to https://github.com/artefactual-labs/ansible-percona/issues/49