### PR TITLE
Don't show user password when creating users

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,3 +8,4 @@
     state: "present"
     host: "{{ item.host | default('localhost') }}"
   with_items: "{{ mysql_users }}"
+  no_log: "true"


### PR DESCRIPTION
Useful when running from Jenkins/AWX