### PR TITLE
Debian 8.11.1, 9.13.0, 10.10.0, 11.0.0 compatibility

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -90,17 +90,9 @@
     state: "present"
   when: mysql_version_major|int >= 8
 
-- name: "Install package dependencies for ansible MySQL modules (python 2)"
+- name: "Install package dependencies for ansible MySQL modules"
   apt:
-    name: "python-mysqldb"
-  when:
-    - ansible_python.version.major == 2
-
-- name: "Install package dependencies for ansible MySQL modules (python 3)"
-  apt:
-    name: "python3-mysqldb"
-  when:
-    - ansible_python.version.major == 3
+    name: "python{{ ansible_python_version is version('3', '>=') | ternary('3', '') }}-mysqldb"
 
 - name: "Adjust permissions of datadir"
   file:


### PR DESCRIPTION
Installing percona-server-server=8.0* on Debian 8 will fail if you install the python-mysqldb package first.