### PR TITLE
Allow for Passwordless Login and move .my.cnf to later

### DIFF
--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -25,14 +25,6 @@
     - ansible_os_family == "RedHat"
     - root_my_cnf_stat.stat.exists == False
 
-- name: "Copy .my.cnf file into the root home folder"
-  template:
-    src: root-my-cnf.j2
-    dest: /root/.my.cnf
-    owner: root
-    group: root
-    mode: 0600
-
 - name: "Set the root password"
   mysql_user:
     name: root
@@ -40,11 +32,20 @@
     password: "{{ mysql_root_password }}"
     check_implicit_admin: yes
     state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
   with_items:
     - "{{ ansible_hostname }}"
     - "127.0.0.1"
     - "::1"
     - "localhost"
+
+- name: "Copy .my.cnf file into the root home folder"
+  template:
+    src: root-my-cnf.j2
+    dest: /root/.my.cnf
+    owner: root
+    group: root
+    mode: 0600
 
 - name: "Ensure anonymous users are not in the database"
   mysql_user:


### PR DESCRIPTION
Allow for passwordless login (the default password on a new install).
Move .my.cnf to be placed after root password has been set.