### PR TITLE
Stop using deprecated `include` module in tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,33 +1,33 @@
 ---
-- include: check-settings.yml
+- import_tasks: check-settings.yml
   tags: check
   when: ansible_os_family not in ['RedHat', 'Rocky']
 
-- include: check-settings-centos.yml
+- import_tasks: check-settings-centos.yml
   tags: check
   when: ansible_os_family in ['RedHat', 'Rocky']
 
-- include: install.yml
+- import_tasks: install.yml
   tags: install
   when: ansible_os_family not in ['RedHat', 'Rocky']
 
-- include: install-centos.yml
+- import_tasks: install-centos.yml
   tags: install
   when: ansible_os_family in ['RedHat', 'Rocky']
 
-- include: configure.yml
+- import_tasks: configure.yml
   tags: configure
   when: ansible_os_family not in ['RedHat', 'Rocky']
 
-- include: configure-centos.yml
+- import_tasks: configure-centos.yml
   tags: configure
   when: ansible_os_family in ['RedHat', 'Rocky']
 
-- include: secure.yml
+- import_tasks: secure.yml
   tags: secure
 
-- include: databases.yml
+- import_tasks: databases.yml
   tags: databases
 
-- include: users.yml
+- import_tasks: users.yml
   tags: users


### PR DESCRIPTION
The `include` module will not work anymore in ansible 2.16 and was set as deprecated in ansible 2.4 (at least).