### PR TITLE
RPM: Change percona-release setup -y position

### DIFF
--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -27,7 +27,7 @@
 
 # https://www.percona.com/doc/percona-server/LATEST/installation/yum_repo.html
 - name: "Enable Percona repository (Percona version >= 8)"
-  command: "percona-release setup ps{{ mysql_version_major }}{{ mysql_version_minor }} -y"
+  command: "percona-release setup -y ps{{ mysql_version_major }}{{ mysql_version_minor }}"
   when: mysql_version_major|int >= 8 and install_rpm_repositories|bool
   changed_when: False     # TODO: check for task idempotency
 


### PR DESCRIPTION
Since percona-release-1.0-31.noarch.rpm the -y argument position must be located before the repository name.

Connects to https://github.com/artefactual-labs/ansible-percona/issues/88