### PR TITLE
Add percona 8.4 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ mysql_version: "{{ mysql_version_major|int }}.{{ mysql_version_minor|int }}"
 mysql_root_password: "pass"
 mysql_port: "3306"
 mysql_bind_address: "127.0.0.1"
-mysql_language: "/usr/share/mysql/"
+mysql_language: "/usr/share/mysql/" # Only for MySQL < 8.4
 mysql_datadir: "/var/lib/mysql"
 
 # Fine tuning
@@ -34,6 +34,7 @@ mysql_collation_server: "utf8_general_ci"
 mysql_mysqldump_max_allowed_packet: "128M"
 mysql_isamchk_key_buffer: "16M"
 mysql_sort_buffer_size: "256K"
+
 
 # InnoDB tuning
 mysql_innodb_file_per_table: "1"
@@ -61,5 +62,13 @@ install_rpm_repositories: "true"
 mysql_disable_log_bin: "true"
 
 # Default Auth Plugin
-# used in templates when Percona Server >= 5.7
+# used in templates when Percona Server >= 5.7 and < 8.4
 mysql_default_authentication_plugin: "mysql_native_password"
+
+# MySQL 8.4 auth
+# Allow to use old mysql_native_password passwords
+mysql_enable_legacy_authentication_plugin: True
+# See https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_authentication_policy
+# Default value allows to use caching_sha2_password for new users, and will auth with others when mysql_enable_legacy_authentication_plugin=True
+mysql_authentication_policy: '*,,'
+

--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -26,9 +26,22 @@
   when: install_rpm_repositories|bool
 
 # https://www.percona.com/doc/percona-server/LATEST/installation/yum_repo.html
-- name: "Enable Percona repository (Percona version >= 8)"
+- name: "Enable Percona repository (Percona version >= 8 and not 8.4)"
   command: "percona-release setup -y ps{{ mysql_version_major }}{{ mysql_version_minor }}"
-  when: mysql_version_major|int >= 8 and install_rpm_repositories|bool
+  when:
+    - mysql_version_major|int >= 8
+    - mysql_version_minor|int != 4
+    - install_rpm_repositories|bool
+  changed_when: False     # TODO: check for task idempotency
+
+#https://docs.percona.com/percona-server/8.4/yum-repo.html#install-using-dnf-rhel-8
+# note, percona 84 use a different format: ps-84-lts instead of ps84
+- name: "Enable Percona repository (Percona version == 8.4)"
+  command: "percona-release setup -y ps-{{ mysql_version_major }}{{ mysql_version_minor }}-lts"
+  when:
+    - mysql_version_major|int >= 8
+    - mysql_version_minor|int == 4
+    - install_rpm_repositories|bool
   changed_when: False     # TODO: check for task idempotency
 
 - name: "Enable Percona toolkit (RH/CentOS/Rocky >= 8.0)"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,10 +18,22 @@
     update_cache: yes
 
 # https://www.percona.com/doc/percona-server/LATEST/installation/apt_repo.html
-- name: "Enable Percona repository (Percona version >= 8)"
+- name: "Enable Percona repository (Percona version >= 8.0 and != 8.4 )"
   command: "percona-release setup ps{{ mysql_version_major }}{{ mysql_version_minor }}"
-  when: mysql_version_major|int >= 8
+  when:
+    - mysql_version_major|int >= 8
+    - mysql_version_minor|int != 4
   changed_when: False     # TODO: check for task idempotency
+
+#https://docs.percona.com/percona-server/8.4/apt-repo.html#install-percona-server-for-mysql-using-apt
+# note, percona 84 use a different format: ps-84-lts instead of ps84
+- name: "Enable Percona repository (Percona version == 8.4 )"
+  command: "percona-release setup ps-{{ mysql_version_major }}{{ mysql_version_minor }}-lts"
+  when:
+    - mysql_version_major|int >= 8
+    - mysql_version_minor|int == 4
+  changed_when: False     # TODO: check for task idempotency
+
 
 - name: "Install python-is-python3 (Ubuntu >= Focal/20.04)"
   apt:

--- a/templates/etc_my.cnf-centos.j2
+++ b/templates/etc_my.cnf-centos.j2
@@ -34,12 +34,22 @@ disable_log_bin
 {% if mysql_sql_mode is defined %}
 sql_mode={{ mysql_sql_mode }}
 {% endif %}
-{% if mysql_default_authentication_plugin is defined and mysql_version is version('5.7', '>=') %}
-default_authentication_plugin={{ mysql_default_authentication_plugin }}
+{% if mysql_default_authentication_plugin is defined and mysql_version is version('5.7', '>=') and mysql_version is version('8.4', '<') %}
+default_authentication_plugin = {{ mysql_default_authentication_plugin }}
 {% endif %}
 
+{% if mysql_enable_legacy_authentication_plugin|bool and  mysql_version is version('8.4', '>=') %}
+mysql_native_password = ON
+{% endif %}
+
+{% if mysql_authentication_policy is defined and  mysql_version is version('8.4', '>=') %}
+authentication_policy = {{ mysql_authentication_policy }}
+{% endif %}
+
+{% if mysql_version is version('8.4', '<') %}
 # language is for pre-5.5. In 5.5 it is an alias for lc_messages_dir.
 language = {{ mysql_language }}
+{% endif %}
 bind-address = {{ mysql_bind_address }}
 skip-external-locking
 
@@ -88,7 +98,11 @@ log_error_verbosity = 1
 # The following can be used as easy to replay backup logs or for replication.
 #server-id      = 1
 #log_bin            = /var/log/mysql/mysql-bin.log
+{% if mysql_version is version('8.4', '<') %}
 expire_logs_days    = 10
+{% else %}
+binlog_expire_logs_seconds = 864000
+{% endif %}
 max_binlog_size     = 100M
 #binlog_do_db       = include_database_name
 #binlog_ignore_db   = include_database_name
@@ -117,7 +131,10 @@ optimizer_switch = {{ mysql_optimizer_switch }}
 
 character_set_server = {{ mysql_character_set_server }}
 collation_server = {{ mysql_collation_server }}
+{% if mysql_character_set_client_handshake is defined and mysql_version is version('8.4', '<') %}
 character-set-client-handshake = {{ mysql_character_set_client_handshake }}
+{% endif %}
+
 
 [mysqldump]
 quick

--- a/templates/etc_mysql_my.cnf.j2
+++ b/templates/etc_mysql_my.cnf.j2
@@ -36,9 +36,18 @@ skip-external-locking
 {% if mysql_sql_mode is defined %}
 sql_mode={{ mysql_sql_mode }}
 {% endif %}
-{% if mysql_default_authentication_plugin is defined and mysql_version is version('5.7', '>=') %}
-default_authentication_plugin={{ mysql_default_authentication_plugin }}
+{% if mysql_default_authentication_plugin is defined and mysql_version is version('5.7', '>=') and mysql_version is version('8.4', '<') %}
+default_authentication_plugin = {{ mysql_default_authentication_plugin }}
 {% endif %}
+
+{% if mysql_enable_legacy_authentication_plugin|bool and  mysql_version is version('8.4', '>=') %}
+mysql_native_password = ON
+{% endif %}
+
+{% if mysql_authentication_policy is defined and  mysql_version is version('8.4', '>=') %}
+authentication_policy = {{ mysql_authentication_policy }}
+{% endif %}
+
 
 # * Fine Tuning
 key_buffer_size         = {{ mysql_key_buffer }}
@@ -86,7 +95,12 @@ log_error_verbosity = 1
 # The following can be used as easy to replay backup logs or for replication.
 #server-id      = 1
 #log_bin            = /var/log/mysql/mysql-bin.log
+{% if mysql_version is version('8.4', '<') %}
 expire_logs_days    = 10
+{% else %}
+binlog_expire_logs_seconds = 864000
+{% endif %}
+
 max_binlog_size     = 100M
 #binlog_do_db       = include_database_name
 #binlog_ignore_db   = include_database_name
@@ -115,7 +129,9 @@ optimizer_switch = {{ mysql_optimizer_switch }}
 
 character_set_server = {{ mysql_character_set_server }}
 collation_server = {{ mysql_collation_server }}
+{% if mysql_character_set_client_handshake is defined and mysql_version is version('8.4', '<') %}
 character-set-client-handshake = {{ mysql_character_set_client_handshake }}
+{% endif %}
 
 [mysqldump]
 quick


### PR DESCRIPTION
Some changes were added to allow to use percona 8.4 lts:

* Use a different setup name for lts version (adding -lts suffix )

Some changes added in my.cnf templates for obsolete or new 8.4 variables. For authentication, 2 new variables are neeeded:

* mysql_enable_legacy_authentication_plugin
* mysql_authentication_policy

The default values will allow to use old passwords, but new users will use new password algorithm.

Connected to https://github.com/archivematica/Issues/issues/1779