### PR TITLE
fix(check-settings.yml/check-settings-centos.yml): enable "Check for innodb_log_file_size setting" tasks to run in checkmode

### DIFF
--- a/tasks/check-settings-centos.yml
+++ b/tasks/check-settings-centos.yml
@@ -13,6 +13,7 @@
     removes: "/etc/my.cnf"
   register: configured_innodb_log_file_size
   changed_when: False
+  check_mode: False
 
 - name: "Abort when innodb_log_file_size changes"
   fail:

--- a/tasks/check-settings.yml
+++ b/tasks/check-settings.yml
@@ -13,6 +13,7 @@
     removes: "/etc/mysql/my.cnf"
   register: configured_innodb_log_file_size
   changed_when: False
+  check_mode: False
 
 - name: "Abort when innodb_log_file_size changes"
   fail:


### PR DESCRIPTION
When running in checkmode, no value was being saved, and it was erroring on the next step
